### PR TITLE
Bump up google-cloud-monitoring to v0.24.x

### DIFF
--- a/fluent-plugin-stackdriver-monitoring.gemspec
+++ b/fluent-plugin-stackdriver-monitoring.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency 'fluentd', ['>= 0.12.0', '< 2']
-  gem.add_runtime_dependency 'google-cloud-monitoring', '~> 0.21.0'
+  gem.add_runtime_dependency 'google-cloud-monitoring', '~> 0.24.0'
 
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
`MetricServiceApi` has been renamed to `MetricServiceClient`.