### PR TITLE
Custom metric does not support some metric types and value types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,15 @@ Sample configuration is below.
     - Set name of descriptor. It must start with `custom.googleapis.com/`.
   - metric_kind(enum, required)
     - See [metric kind](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors#MetricKind).
-    - You can specify `GAUGE`, `DELTA` or `CUMULATIVE`.
+    - You can specify `GAUGE` or `CUMULATIVE`.
+    - Custom metric does not support `DELTA`. See [here](https://cloud.google.com/monitoring/api/v3/metrics?hl=en#metric-kinds).
   - value_type(enum, required)
     - See [value type](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors#valuetype).
-    - You can specify `BOOL`, `INT64`, `DOUBLE` or `STRING`.
+    - You can specify `BOOL`, `INT64` or `DOUBLE` if metric_kind is `GAUGE`. And `INT64` or `DOUBLE` can be specified if metric_kind is `CUMULATIVE`.
+    - Custom metric does not support `MONEY` and `STRING`. See [here](https://cloud.google.com/monitoring/api/v3/metrics?hl=en#metric-kinds).
   - time_interval(time, optional)
     - This param is used as the difference between start time and end time.
-    - It must be greater than 0s if metric_kind is set to DELTA or CUMULATIVE.
+    - It must be greater than 0s if metric_kind is set to `CUMULATIVE`.
 
 ## TODO
 

--- a/lib/fluent/plugin/out_stackdriver_monitoring.rb
+++ b/lib/fluent/plugin/out_stackdriver_monitoring.rb
@@ -115,7 +115,7 @@ module Fluent
       typed_value = Google::Monitoring::V3::TypedValue.new
       case @metric_descriptor.value_type
       when :BOOL
-        typed_value.bool_value = value.to_bool
+        typed_value.bool_value = !!value
       when :INT64
         typed_value.int64_value = value.to_i
       when :DOUBLE

--- a/lib/fluent/plugin/out_stackdriver_monitoring.rb
+++ b/lib/fluent/plugin/out_stackdriver_monitoring.rb
@@ -12,8 +12,8 @@ module Fluent
     config_section :custom_metrics, required: true, multi: false do
       config_param :key, :string
       config_param :type, :string
-      config_param :metric_kind, :enum, list: [:GAUGE, :DELTA, :CUMULATIVE]
-      config_param :value_type, :enum, list: [:BOOL, :INT64, :DOUBLE, :STRING] # todo: implement :DISTRIBUTION, :MONEY
+      config_param :metric_kind, :enum, list: [:GAUGE, :CUMULATIVE]
+      config_param :value_type, :enum, list: [:BOOL, :INT64, :DOUBLE] # todo: implement :DISTRIBUTION
       config_param :time_interval, :time, default: 0
     end
 
@@ -22,12 +22,17 @@ module Fluent
     def configure(conf)
       super
 
-      unless @custom_metrics.type.start_with? TYPE_PREFIX
+      unless is_custom_metric? @custom_metrics.type
         raise Fluent::ConfigError.new "custom_metrics.type must start with \"#{TYPE_PREFIX}\""
       end
 
-      if @custom_metrics.metric_kind != :GAUGE && @custom_metrics.time_interval == 0
-        raise Fluent::ConfigError.new "time_interval must be greater than 0 if metric_kind is set to DELTA or CUMULATIVE."
+      if @custom_metrics.metric_kind == :CUMULATIVE
+        if @custom_metrics.time_interval == 0
+          raise Fluent::ConfigError.new 'time_interval must be greater than 0 if metric_kind is set to CUMULATIVE'
+        end
+        if @custom_metrics.value_type == :BOOL
+          raise Fluent::ConfigError.new 'custom metric does not support BOOL value type if metric_kind is set to CUMULATIVE'
+        end
       end
 
       @project_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path @project
@@ -62,6 +67,10 @@ module Fluent
     end
 
     private
+    def is_custom_metric?(metric_type)
+      metric_type.start_with? TYPE_PREFIX
+    end
+
     def create_metric_descriptor
       begin
         metric_descriptor = @metric_service_client.get_metric_descriptor(@metric_name)
@@ -111,8 +120,6 @@ module Fluent
         typed_value.int64_value = value.to_i
       when :DOUBLE
         typed_value.double_value = value.to_f
-      when :STRING
-        typed_value.string_value = value.to_s
       else
         raise 'Unknown value_type!'
       end

--- a/test/plugin/test_out_stackdriver_monitoring.rb
+++ b/test/plugin/test_out_stackdriver_monitoring.rb
@@ -45,20 +45,7 @@ class StackdriverMonitoringOutputTest < Test::Unit::TestCase
       end
     end
 
-    test 'time_interval must be greater than 0 if metric_kind is set to DELTA or CUMULATIVE' do
-      assert_raises Fluent::ConfigError do
-        create_driver(%[
-          project project-test
-          <custom_metrics>
-            key hoge_key
-            type invalid_type
-            metric_kind DELTA
-            value_type INT64
-            time_interval 0s
-          </custom_metrics>
-        ])
-      end
-
+    test 'time_interval must be greater than 0 if metric_kind is set to CUMULATIVE' do
       assert_raises Fluent::ConfigError do
         create_driver(%[
           project project-test
@@ -68,6 +55,20 @@ class StackdriverMonitoringOutputTest < Test::Unit::TestCase
             metric_kind CUMULATIVE
             value_type INT64
             time_interval 0s
+          </custom_metrics>
+        ])
+      end
+    end
+
+    test 'custom metric does not support BOOL value type if metric_kind is set to CUMULATIVE' do
+      assert_raises Fluent::ConfigError do
+        create_driver(%[
+          project project-test
+          <custom_metrics>
+            key hoge_key
+            type invalid_type
+            metric_kind CUMULATIVE
+            value_type BOOL
           </custom_metrics>
         ])
       end


### PR DESCRIPTION
See https://cloud.google.com/monitoring/api/v3/metrics?hl=en#metric-kinds
Related to #5 
